### PR TITLE
Allow hiding icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,12 @@ colorscheme gruvbox
 hi DirvishGitModified guifg=#0000FF
 ```
 
+Icons are shown by default, to hide the icons and only show the Git status with 
+colors, add this to your vimrc:
+
+```vimL
+let g:dirvish_git_show_icons = 0
+```
+
 ## Thanks to:
 * [nerdtree-git-plugin](https://github.com/Xuyuanp/nerdtree-git-plugin)

--- a/plugin/dirvish_git.vim
+++ b/plugin/dirvish_git.vim
@@ -4,6 +4,7 @@ endif
 let g:loaded_dirvish_git = 1
 
 let g:dirvish_git_show_ignored = get(g:, 'dirvish_git_show_ignored', 0)
+let g:dirvish_git_show_icons = get(g:, 'dirvish_git_show_icons', 1)
 
 if !exists('g:dirvish_git_indicators')
   let g:dirvish_git_indicators = {
@@ -147,9 +148,15 @@ function! s:highlight_file(dir, file_name, us, them, is_directory) abort
   let l:dir_rgx = escape(printf('%s\(%s%s\)\@=', a:dir, s:sep, a:file_name), s:escape_chars)
   let l:slash_rgx = escape(printf('\(%s\)\@<=%s\(%s\)\@=', a:dir, s:sep, a:file_name), s:escape_chars)
 
-  silent exe 'syn match DirvishGitDir "'.l:dir_rgx.'" conceal cchar='.s:get_indicator(a:us, a:them)
+  " Check if icons should be shown
+  let l:conceal_char = g:dirvish_git_show_icons
+        \ ? ' cchar=' .. s:get_indicator(a:us, a:them)
+        \ : ''
+  let l:conceal_last_folder_char = g:dirvish_git_show_icons ? ' cchar= ' : ''
+
+  silent exe 'syn match DirvishGitDir "'.l:dir_rgx.'" conceal' .. l:conceal_char
   silent exe 'syn match '.s:get_highlight_group(a:us, a:them, a:is_directory).' "'.l:file_rgx.'" contains=DirvishGitSlash'
-  silent exe 'syn match DirvishGitSlash "'.l:slash_rgx.'" conceal cchar= contained'
+  silent exe 'syn match DirvishGitSlash "'.l:slash_rgx.'" conceal contained' .. l:conceal_last_folder_char
 endfunction
 
 function! s:setup_highlighting() abort


### PR DESCRIPTION
Hey! I moved from NERDTree and [`nerdtree-git-plugin`](https://github.com/Xuyuanp/nerdtree-git-plugin) to Dirvish but one functionality that I missed was to disable icons entirely. So, I went ahead and implemented it since it seems like a nice feature to have.

Initially I tried something like this:

```vimL
let g:dirvish_git_indicators = {
      \ 'Modified'  : ' ',
      \ 'Staged'    : ' ',
      \ 'Untracked' : ' ',
      \ 'Renamed'   : ' ',
      \ 'Unmerged'  : ' ',
      \ 'Ignored'   : ' ',
      \ 'Unknown'   : ' '
      \ }
```

But that still left an empty space instead of the icon.

It is now possible to use the `g:dirvish_git_show_icons` variable to hide icons:

```vimL
let g:dirvish_git_show_icons = 0
```

---

**A small comparison:**

With icons:

<img width="182" alt="image" src="https://user-images.githubusercontent.com/9450943/83230429-6630e900-a192-11ea-8fdf-277f1cb2338d.png">

Without icons:

<img width="167" alt="image" src="https://user-images.githubusercontent.com/9450943/83230448-70eb7e00-a192-11ea-80ca-3ee7d862af15.png">
