### PR TITLE
Fix folders that include ignored files

### DIFF
--- a/plugin/dirvish_git.vim
+++ b/plugin/dirvish_git.vim
@@ -76,6 +76,20 @@ function! dirvish_git#init() abort
     endif
 
     let l:file = fnamemodify(l:file, ':p')
+
+    if l:us ==# '!'
+      " Handle ignored files and directories. If there is an ignored file in a 
+      " sub-folder, then the whole folder should not be marked as ignored.
+
+      " Get the parent folder relative path of the ignored file/folder
+      let l:folder_of_file = fnamemodify(l:file, ':s?' .. expand('%') .. '??:s?/$??:h')
+      if l:folder_of_file !=# '.'
+        " If the ignored file/folder is NOT in the currently open directory, 
+        " then it should NOT be shown as ignored
+        continue
+      endif
+    endif
+
     let l:file = matchstr(l:file, escape(l:current_dir.'[^'.s:sep.']*'.s:sep.'\?', s:escape_chars))
 
     if index(values(s:git_files), l:file) > -1


### PR DESCRIPTION
Hey! I've another pull request if you're not too busy.

If a folder includes a file that has been ignored, then it would almost always be shown as "ignored", even if the folder also contains files that have NOT been ignored.

An example file structure:

```
.
├── .gitignore
└── folder
    ├── ignored.txt
    └── not_ignored.txt
```

Where the `.gitignore` file includes the following:

```
folder/ignored.txt
```

This causes the whole `folder/` entry to be marked as "ignored" even though `not_ignored.txt` is not ignored. This doesn't seem to make sense to me and I think that a folder should be marked as "ignored" _only_ if all of the files inside it are ignored.

One thing I'm not too sure about is running `expand('%')` in every loop iteration -- I'm not sure if it has any performance impact.

---

**Visual example:**

Without my patch:

<img width="532" alt="Screenshot 2020-05-29 at 16 33 41" src="https://user-images.githubusercontent.com/9450943/83265593-651bae00-a1ca-11ea-9849-75f70c32db11.png">

With my patch:

<img width="517" alt="Screenshot 2020-05-29 at 16 34 50" src="https://user-images.githubusercontent.com/9450943/83265620-6b118f00-a1ca-11ea-86eb-a40e4d5bf8b0.png">
